### PR TITLE
Fix broken link to software

### DIFF
--- a/_posts/2022-05-03-chen22a.md
+++ b/_posts/2022-05-03-chen22a.md
@@ -12,7 +12,7 @@ abstract: " We present a principled approach for designing stochastic Newton met
   that SAN requires no knowledge about the problem, neither parameter tuning, while
   remaining competitive as compared to classical variance reduced gradient methods
   (e.g. SAG and SVRG), incremental Newton and quasi-Newton methods (e.g. SNM, IQN). "
-software: " https://github.com/ nathansiae/Stochastic-Average-Newton "
+software: " https://github.com/nathansiae/Stochastic-Average-Newton "
 layout: inproceedings
 series: Proceedings of Machine Learning Research
 publisher: PMLR


### PR DESCRIPTION
A spurious space was inserted in the Github adress, breaking the link